### PR TITLE
Board selection

### DIFF
--- a/background.js
+++ b/background.js
@@ -301,33 +301,36 @@ async function handleFetchRecentBugs(message, sendResponse) {
   try {
     console.log('Handling fetchRecentBugs request...');
     const settings = await chrome.storage.sync.get(['mondayToken', 'selectedBoardId', 'selectedGroupId']);
-    
+
+    // Allow the popup to specify which saved configuration to view. Fall back
+    // to the stored default (selectedBoardId/selectedGroupId) when not provided.
+    const boardId = message.boardId || settings.selectedBoardId;
+    const groupId = message.groupId || settings.selectedGroupId;
+
     console.log('Settings for fetch:', {
       hasToken: !!settings.mondayToken,
-      boardId: settings.selectedBoardId,
-      groupId: settings.selectedGroupId
+      boardId,
+      groupId,
+      overridden: !!(message.boardId && message.groupId)
     });
-    
+
     if (!settings.mondayToken) {
       console.error('No Monday token found');
       sendResponse({ success: false, error: 'Monday.com not connected. Please configure your API token in settings.' });
       return;
     }
-    
-    if (!settings.selectedBoardId || !settings.selectedGroupId) {
+
+    if (!boardId || !groupId) {
       console.error('No board/group selected');
       sendResponse({ success: false, error: 'Please select a board and group in settings' });
       return;
     }
-    
+
     mondayAPI.setToken(settings.mondayToken);
-    
+
     console.log('Fetching bugs from Monday...');
-    const bugs = await mondayAPI.fetchRecentItems(
-      settings.selectedBoardId,
-      settings.selectedGroupId
-    );
-    
+    const bugs = await mondayAPI.fetchRecentItems(boardId, groupId);
+
     console.log('Bugs fetched successfully:', bugs.length);
     sendResponse({ success: true, bugs });
   } catch (error) {

--- a/modules/monday-api.js
+++ b/modules/monday-api.js
@@ -171,12 +171,14 @@ export class MondayAPI {
     return allBoards;
   }
 
-  async fetchRecentItems(boardId, groupId, limit = 10) {
-    const query = `
+  async fetchRecentItems(boardId, groupId, limit = 500) {
+    // Fetch the first page scoped to the selected group, ordered newest-first.
+    const firstPageQuery = `
       query ($boardId: [ID!]!, $limit: Int!) {
         boards(ids: $boardId) {
           groups(ids: ["${groupId}"]) {
             items_page(limit: $limit, query_params: { order_by: [{column_id: "__creation_log__", direction: desc}] }) {
+              cursor
               items {
                 id
                 name
@@ -200,16 +202,67 @@ export class MondayAPI {
       }
     `;
 
-    const data = await this.query(query, { 
-      boardId: [boardId], 
-      limit 
+    const firstPageData = await this.query(firstPageQuery, {
+      boardId: [boardId],
+      limit
     });
 
-    if (data.boards && data.boards[0] && data.boards[0].groups[0]) {
-      return data.boards[0].groups[0].items_page.items;
+    if (!firstPageData.boards || !firstPageData.boards[0] || !firstPageData.boards[0].groups[0]) {
+      return [];
     }
 
-    return [];
+    const firstPage = firstPageData.boards[0].groups[0].items_page;
+    const allItems = [...(firstPage.items || [])];
+    let cursor = firstPage.cursor;
+
+    // Follow the cursor to gather every remaining item in the group.
+    // Monday's next_items_page is not scoped by group, but the cursor from a
+    // group-scoped items_page only yields items from that same group.
+    const nextPageQuery = `
+      query ($cursor: String!, $limit: Int!) {
+        next_items_page(cursor: $cursor, limit: $limit) {
+          cursor
+          items {
+            id
+            name
+            url
+            created_at
+            updated_at
+            column_values {
+              id
+              text
+              value
+              column {
+                title
+                type
+                settings_str
+              }
+            }
+          }
+        }
+      }
+    `;
+
+    // Safety cap to avoid runaway loops on unexpectedly huge boards.
+    const maxPages = 100;
+    let pagesFetched = 1;
+
+    while (cursor && pagesFetched < maxPages) {
+      const nextData = await this.query(nextPageQuery, { cursor, limit });
+      const page = nextData.next_items_page;
+      if (!page) break;
+
+      if (Array.isArray(page.items) && page.items.length > 0) {
+        allItems.push(...page.items);
+      }
+
+      cursor = page.cursor;
+      pagesFetched++;
+
+      if (!cursor) break;
+    }
+
+    return allItems;
   }
 
   async fetchBoardColumns(boardId) {

--- a/popup.html
+++ b/popup.html
@@ -28,6 +28,12 @@
       <span id="statusText">Not connected to Monday.com</span>
     </div>
 
+    <!-- Configuration Switcher (hidden when <= 1 saved configurations) -->
+    <div class="config-switcher" id="configSwitcher" hidden>
+      <label for="configSelect" class="config-switcher-label">Bug list:</label>
+      <select id="configSelect" class="config-switcher-select"></select>
+    </div>
+
     <!-- Search Box -->
     <div class="search-container">
       <input 

--- a/scripts/create-bug.js
+++ b/scripts/create-bug.js
@@ -1063,11 +1063,9 @@ document.addEventListener('DOMContentLoaded', async () => {
 
       console.log('Validation passed, creating bug with:', { title, boardId, groupId });
 
-      // Save board/group selection
-      await chrome.storage.sync.set({
-        selectedBoardId: boardId,
-        selectedGroupId: groupId
-      });
+      // Do NOT persist board/group here — the default configuration is managed
+      // from the Settings page (Bug Lists). Ad-hoc board/group changes on this
+      // page are one-off for the current submission.
 
       // Gather bug data
       const bugData = {

--- a/scripts/popup.js
+++ b/scripts/popup.js
@@ -3,6 +3,11 @@
 let allBugs = []; // Store all bugs for client-side filtering
 let filteredBugs = []; // Currently displayed bugs
 
+// Saved configurations + which one the popup is currently viewing
+let savedConfigurations = [];
+let defaultConfigurationId = null;
+let activeConfigId = null;
+
 document.addEventListener('DOMContentLoaded', async () => {
   // Easter Egg: Click logo 17 times to open random Oggy video
   const logoImg = document.querySelector('.logo img');
@@ -54,12 +59,29 @@ document.addEventListener('DOMContentLoaded', async () => {
   const statusText = document.getElementById('statusText');
   const searchInput = document.getElementById('searchInput');
   const resultsCount = document.getElementById('resultsCount');
+  const configSwitcher = document.getElementById('configSwitcher');
+  const configSelect = document.getElementById('configSelect');
+
+  // Load saved configurations and pick the active one
+  await loadConfigurations();
 
   // Check connection status
   await checkConnectionStatus();
 
-  // Load recent bugs
+  // Populate the config switcher dropdown
+  renderConfigSwitcher();
+
+  // Load recent bugs for the active configuration
   await loadRecentBugs();
+
+  configSelect.addEventListener('change', async (e) => {
+    activeConfigId = e.target.value;
+    await chrome.storage.local.set({ activePopupConfigId: activeConfigId });
+    allBugs = [];
+    filteredBugs = [];
+    searchInput.value = '';
+    await loadRecentBugs();
+  });
 
   // Search functionality with debounce
   let searchTimeout;
@@ -85,16 +107,87 @@ document.addEventListener('DOMContentLoaded', async () => {
     chrome.tabs.create({ url: 'update-bug.html' });
   });
 
+  async function loadConfigurations() {
+    try {
+      const sync = await chrome.storage.sync.get([
+        'savedConfigurations',
+        'defaultConfigurationId'
+      ]);
+      const local = await chrome.storage.local.get(['activePopupConfigId']);
+
+      savedConfigurations = Array.isArray(sync.savedConfigurations)
+        ? sync.savedConfigurations
+        : [];
+      defaultConfigurationId = sync.defaultConfigurationId || null;
+
+      const storedActiveId = local.activePopupConfigId || null;
+      const hasStoredActive = storedActiveId &&
+        savedConfigurations.some(cfg => cfg.id === storedActiveId);
+      const hasDefault = defaultConfigurationId &&
+        savedConfigurations.some(cfg => cfg.id === defaultConfigurationId);
+
+      if (hasStoredActive) {
+        activeConfigId = storedActiveId;
+      } else if (hasDefault) {
+        activeConfigId = defaultConfigurationId;
+      } else if (savedConfigurations.length > 0) {
+        activeConfigId = savedConfigurations[0].id;
+      } else {
+        activeConfigId = null;
+      }
+
+      // If the stored active id was stale, tidy up
+      if (storedActiveId && !hasStoredActive) {
+        if (activeConfigId) {
+          await chrome.storage.local.set({ activePopupConfigId: activeConfigId });
+        } else {
+          await chrome.storage.local.remove(['activePopupConfigId']);
+        }
+      }
+    } catch (error) {
+      console.error('Error loading configurations:', error);
+      savedConfigurations = [];
+      defaultConfigurationId = null;
+      activeConfigId = null;
+    }
+  }
+
+  function renderConfigSwitcher() {
+    if (savedConfigurations.length <= 1) {
+      configSwitcher.hidden = true;
+      return;
+    }
+
+    configSwitcher.hidden = false;
+    configSelect.innerHTML = '';
+
+    savedConfigurations.forEach(cfg => {
+      const option = document.createElement('option');
+      option.value = cfg.id;
+      const isDefault = cfg.id === defaultConfigurationId ? ' (default)' : '';
+      option.textContent = `${cfg.boardName} / ${cfg.groupTitle}${isDefault}`;
+      if (cfg.id === activeConfigId) {
+        option.selected = true;
+      }
+      configSelect.appendChild(option);
+    });
+  }
+
+  function getActiveConfiguration() {
+    if (!activeConfigId) return null;
+    return savedConfigurations.find(cfg => cfg.id === activeConfigId) || null;
+  }
+
   async function checkConnectionStatus() {
     try {
-      const settings = await chrome.storage.sync.get(['mondayToken', 'selectedBoardId', 'selectedGroupId']);
-      
-      if (settings.mondayToken && settings.selectedBoardId && settings.selectedGroupId) {
+      const settings = await chrome.storage.sync.get(['mondayToken']);
+
+      if (settings.mondayToken && getActiveConfiguration()) {
         statusIndicator.className = 'status-indicator connected';
         statusText.textContent = 'Connected to Monday.com';
       } else if (settings.mondayToken) {
         statusIndicator.className = 'status-indicator warning';
-        statusText.textContent = 'Please select board and group';
+        statusText.textContent = 'Please add a bug list in settings';
       } else {
         statusIndicator.className = 'status-indicator disconnected';
         statusText.textContent = 'Not connected to Monday.com';
@@ -107,16 +200,24 @@ document.addEventListener('DOMContentLoaded', async () => {
   async function loadRecentBugs() {
     try {
       console.log('Loading recent bugs...');
-      const settings = await chrome.storage.sync.get(['mondayToken', 'selectedBoardId', 'selectedGroupId']);
-      
+      const settings = await chrome.storage.sync.get(['mondayToken']);
+      const activeConfig = getActiveConfiguration();
+
       console.log('Settings loaded:', {
         hasToken: !!settings.mondayToken,
-        boardId: settings.selectedBoardId,
-        groupId: settings.selectedGroupId
+        activeConfigId,
+        boardId: activeConfig?.boardId,
+        groupId: activeConfig?.groupId
       });
-      
-      if (!settings.mondayToken || !settings.selectedBoardId || !settings.selectedGroupId) {
+
+      if (!settings.mondayToken) {
         bugsList.innerHTML = '<div class="empty-state">Connect to Monday.com in settings to view bugs</div>';
+        resultsCount.textContent = '';
+        return;
+      }
+
+      if (!activeConfig) {
+        bugsList.innerHTML = '<div class="empty-state">Add a bug list in settings to view bugs</div>';
         resultsCount.textContent = '';
         return;
       }
@@ -124,9 +225,13 @@ document.addEventListener('DOMContentLoaded', async () => {
       bugsList.innerHTML = '<div class="loading">Loading bugs...</div>';
       resultsCount.textContent = '';
 
-      // Request bugs from background script
+      // Request bugs from background script, scoped to the active configuration
       chrome.runtime.sendMessage(
-        { action: 'fetchRecentBugs' },
+        {
+          action: 'fetchRecentBugs',
+          boardId: activeConfig.boardId,
+          groupId: activeConfig.groupId
+        },
         (response) => {
           console.log('Received bugs response:', response);
           

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -4,6 +4,15 @@
 let allBoards = [];
 let filteredBoards = [];
 
+// In-memory saved configurations state (mirrors chrome.storage.sync)
+let savedConfigurations = [];
+let defaultConfigurationId = null;
+
+// Build a stable id from board + group ids
+function buildConfigId(boardId, groupId) {
+  return `${boardId}:${groupId}`;
+}
+
 document.addEventListener('DOMContentLoaded', async () => {
   // Easter Egg: Click logo 17 times to open random Oggy video
   const logoImg = document.querySelector('.header-logo');
@@ -56,7 +65,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   document.getElementById('saveTokenBtn').addEventListener('click', saveToken);
   document.getElementById('disconnectBtn').addEventListener('click', disconnect);
   document.getElementById('boardSelect').addEventListener('change', loadGroups);
-  document.getElementById('saveSelectionBtn').addEventListener('click', saveSelection);
+  document.getElementById('addConfigurationBtn').addEventListener('click', addConfiguration);
   document.getElementById('saveConsentBtn').addEventListener('click', saveConsent);
   document.getElementById('clearDataBtn').addEventListener('click', clearData);
   
@@ -91,6 +100,8 @@ document.addEventListener('DOMContentLoaded', async () => {
         'mondayToken',
         'selectedBoardId',
         'selectedGroupId',
+        'savedConfigurations',
+        'defaultConfigurationId',
         'screenshotConsent'
       ]);
 
@@ -104,18 +115,51 @@ document.addEventListener('DOMContentLoaded', async () => {
       // Consent
       document.getElementById('screenshotConsent').checked = settings.screenshotConsent !== false;
 
-      // Board/Group selection
-      if (settings.selectedBoardId) {
-        document.getElementById('boardSelect').value = settings.selectedBoardId;
-        await loadGroups();
-        
-        if (settings.selectedGroupId) {
-          document.getElementById('groupSelect').value = settings.selectedGroupId;
+      // Saved configurations state (with one-time migration from legacy single selection)
+      savedConfigurations = Array.isArray(settings.savedConfigurations)
+        ? settings.savedConfigurations
+        : [];
+      defaultConfigurationId = settings.defaultConfigurationId || null;
+
+      if (savedConfigurations.length === 0 && settings.selectedBoardId && settings.selectedGroupId) {
+        const migrated = await migrateLegacySelection(
+          settings.selectedBoardId,
+          settings.selectedGroupId
+        );
+        if (migrated) {
+          savedConfigurations = [migrated];
+          defaultConfigurationId = migrated.id;
+          await persistConfigurations();
         }
       }
+
+      renderSavedConfigurations();
     } catch (error) {
       console.error('Error loading settings:', error);
     }
+  }
+
+  // Build a configuration entry from the legacy single selection using already-loaded board data.
+  // Returns null if the board or group can't be resolved (e.g., no longer accessible).
+  async function migrateLegacySelection(boardId, groupId) {
+    const board = allBoards.find(b => String(b.id) === String(boardId));
+    if (!board) {
+      console.warn('Migration skipped: board no longer accessible', boardId);
+      return null;
+    }
+    const group = (board.groups || []).find(g => String(g.id) === String(groupId));
+    if (!group) {
+      console.warn('Migration skipped: group no longer in board', boardId, groupId);
+      return null;
+    }
+    return {
+      id: buildConfigId(board.id, group.id),
+      boardId: String(board.id),
+      boardName: board.name,
+      groupId: String(group.id),
+      groupTitle: group.title,
+      workspaceName: board.workspace?.name || 'No Workspace'
+    };
   }
 
   function toggleTokenVisibility() {
@@ -186,13 +230,20 @@ document.addEventListener('DOMContentLoaded', async () => {
       await chrome.storage.sync.remove([
         'mondayToken',
         'selectedBoardId',
-        'selectedGroupId'
+        'selectedGroupId',
+        'savedConfigurations',
+        'defaultConfigurationId'
       ]);
-      
+      await chrome.storage.local.remove(['activePopupConfigId']);
+
+      savedConfigurations = [];
+      defaultConfigurationId = null;
+
       document.getElementById('mondayToken').value = '';
       document.getElementById('boardSelect').innerHTML = '<option value="">Select a board...</option>';
       document.getElementById('groupSelect').innerHTML = '<option value="">Select board first</option>';
-      
+      renderSavedConfigurations();
+
       updateConnectionStatus(false);
       alert('Disconnected successfully');
     } catch (error) {
@@ -236,14 +287,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         
         // Update count
         updateBoardCount(filteredBoards.length, allBoards.length);
-        
-        // Restore saved selection
-        const settings = await chrome.storage.sync.get(['selectedBoardId']);
-        if (settings.selectedBoardId) {
-          boardSelect.value = settings.selectedBoardId;
-          await loadGroups();
-        }
-        
+
         boardSelect.disabled = false;
         boardSelectStatus.classList.remove('loading');
       } else {
@@ -333,14 +377,14 @@ document.addEventListener('DOMContentLoaded', async () => {
     const boardSelect = document.getElementById('boardSelect');
     const groupSelect = document.getElementById('groupSelect');
     const selectedOption = boardSelect.options[boardSelect.selectedIndex];
-    
+
     if (!selectedOption || !selectedOption.dataset.groups) {
       groupSelect.innerHTML = '<option value="">Select board first</option>';
       return;
     }
 
     const groups = JSON.parse(selectedOption.dataset.groups);
-    
+
     groupSelect.innerHTML = '<option value="">Select a group...</option>';
     groups.forEach(group => {
       const option = document.createElement('option');
@@ -348,33 +392,192 @@ document.addEventListener('DOMContentLoaded', async () => {
       option.textContent = group.title;
       groupSelect.appendChild(option);
     });
-
-    // Restore saved selection
-    const settings = await chrome.storage.sync.get(['selectedGroupId']);
-    if (settings.selectedGroupId) {
-      groupSelect.value = settings.selectedGroupId;
-    }
   }
 
-  async function saveSelection() {
-    const boardId = document.getElementById('boardSelect').value;
-    const groupId = document.getElementById('groupSelect').value;
-    
+  async function addConfiguration() {
+    const boardSelect = document.getElementById('boardSelect');
+    const groupSelect = document.getElementById('groupSelect');
+    const boardId = boardSelect.value;
+    const groupId = groupSelect.value;
+
     if (!boardId || !groupId) {
       alert('Please select both board and group');
       return;
     }
 
-    try {
-      await chrome.storage.sync.set({
-        selectedBoardId: boardId,
-        selectedGroupId: groupId
-      });
-      
-      alert('Selection saved successfully');
-    } catch (error) {
-      alert('Failed to save selection: ' + error.message);
+    const id = buildConfigId(boardId, groupId);
+    if (savedConfigurations.some(cfg => cfg.id === id)) {
+      alert('This board and group combination is already saved.');
+      return;
     }
+
+    const board = allBoards.find(b => String(b.id) === String(boardId));
+    const group = board ? (board.groups || []).find(g => String(g.id) === String(groupId)) : null;
+
+    if (!board || !group) {
+      alert('Could not resolve board or group details. Please try again.');
+      return;
+    }
+
+    const configuration = {
+      id,
+      boardId: String(board.id),
+      boardName: board.name,
+      groupId: String(group.id),
+      groupTitle: group.title,
+      workspaceName: board.workspace?.name || 'No Workspace'
+    };
+
+    savedConfigurations.push(configuration);
+    if (!defaultConfigurationId) {
+      defaultConfigurationId = configuration.id;
+    }
+
+    try {
+      await persistConfigurations();
+      renderSavedConfigurations();
+
+      // Reset the form selections so the next add starts cleanly
+      boardSelect.value = '';
+      groupSelect.innerHTML = '<option value="">Select board first</option>';
+    } catch (error) {
+      // Roll back the in-memory change if persistence fails
+      savedConfigurations = savedConfigurations.filter(c => c.id !== configuration.id);
+      if (defaultConfigurationId === configuration.id) {
+        defaultConfigurationId = savedConfigurations[0]?.id || null;
+      }
+      alert('Failed to add configuration: ' + error.message);
+    }
+  }
+
+  async function setDefaultConfiguration(id) {
+    if (!savedConfigurations.some(cfg => cfg.id === id)) return;
+    const previousDefault = defaultConfigurationId;
+    defaultConfigurationId = id;
+    try {
+      await persistConfigurations();
+      renderSavedConfigurations();
+    } catch (error) {
+      defaultConfigurationId = previousDefault;
+      alert('Failed to set default: ' + error.message);
+    }
+  }
+
+  async function removeConfiguration(id) {
+    const index = savedConfigurations.findIndex(cfg => cfg.id === id);
+    if (index === -1) return;
+
+    const removed = savedConfigurations[index];
+    const confirmMessage = `Remove "${removed.boardName} / ${removed.groupTitle}" from your bug lists?`;
+    if (!confirm(confirmMessage)) return;
+
+    const snapshot = {
+      configs: savedConfigurations.slice(),
+      defaultId: defaultConfigurationId
+    };
+
+    savedConfigurations.splice(index, 1);
+    if (defaultConfigurationId === id) {
+      defaultConfigurationId = savedConfigurations[0]?.id || null;
+    }
+
+    try {
+      await persistConfigurations();
+
+      // If the popup was showing the removed configuration, clear that pointer
+      const local = await chrome.storage.local.get(['activePopupConfigId']);
+      if (local.activePopupConfigId === id) {
+        await chrome.storage.local.remove(['activePopupConfigId']);
+      }
+
+      renderSavedConfigurations();
+    } catch (error) {
+      savedConfigurations = snapshot.configs;
+      defaultConfigurationId = snapshot.defaultId;
+      alert('Failed to remove configuration: ' + error.message);
+    }
+  }
+
+  // Persist savedConfigurations + defaultConfigurationId, and keep legacy
+  // selectedBoardId/selectedGroupId in sync with the default so Create Bug /
+  // Update Bug Case continue to work unchanged.
+  async function persistConfigurations() {
+    const payload = {
+      savedConfigurations,
+      defaultConfigurationId
+    };
+
+    const defaultConfig = savedConfigurations.find(cfg => cfg.id === defaultConfigurationId);
+    if (defaultConfig) {
+      payload.selectedBoardId = defaultConfig.boardId;
+      payload.selectedGroupId = defaultConfig.groupId;
+      await chrome.storage.sync.set(payload);
+    } else {
+      await chrome.storage.sync.set(payload);
+      await chrome.storage.sync.remove(['selectedBoardId', 'selectedGroupId']);
+    }
+  }
+
+  function renderSavedConfigurations() {
+    const container = document.getElementById('savedConfigurations');
+    if (!container) return;
+
+    container.innerHTML = '';
+
+    if (savedConfigurations.length === 0) {
+      const empty = document.createElement('div');
+      empty.className = 'empty-state-inline';
+      empty.textContent = 'No configurations saved yet. Add your first one below.';
+      container.appendChild(empty);
+      return;
+    }
+
+    savedConfigurations.forEach(cfg => {
+      const row = document.createElement('div');
+      row.className = 'config-row' + (cfg.id === defaultConfigurationId ? ' is-default' : '');
+
+      const main = document.createElement('div');
+      main.className = 'config-row-main';
+
+      const title = document.createElement('div');
+      title.className = 'config-row-title';
+      title.textContent = `${cfg.boardName} / ${cfg.groupTitle}`;
+
+      const meta = document.createElement('div');
+      meta.className = 'config-row-meta';
+      meta.textContent = cfg.workspaceName || 'No Workspace';
+
+      main.appendChild(title);
+      main.appendChild(meta);
+
+      const actions = document.createElement('div');
+      actions.className = 'config-row-actions';
+
+      if (cfg.id === defaultConfigurationId) {
+        const badge = document.createElement('span');
+        badge.className = 'config-badge';
+        badge.textContent = 'Default';
+        actions.appendChild(badge);
+      } else {
+        const setDefaultBtn = document.createElement('button');
+        setDefaultBtn.type = 'button';
+        setDefaultBtn.className = 'config-action-btn';
+        setDefaultBtn.textContent = 'Set as default';
+        setDefaultBtn.addEventListener('click', () => setDefaultConfiguration(cfg.id));
+        actions.appendChild(setDefaultBtn);
+      }
+
+      const removeBtn = document.createElement('button');
+      removeBtn.type = 'button';
+      removeBtn.className = 'config-action-btn remove-btn';
+      removeBtn.textContent = 'Remove';
+      removeBtn.addEventListener('click', () => removeConfiguration(cfg.id));
+      actions.appendChild(removeBtn);
+
+      row.appendChild(main);
+      row.appendChild(actions);
+      container.appendChild(row);
+    });
   }
 
   async function saveConsent() {

--- a/scripts/update-bug.js
+++ b/scripts/update-bug.js
@@ -369,8 +369,9 @@ document.addEventListener('DOMContentLoaded', async () => {
     lookupCandidates.style.display = 'none';
     lookupCandidates.innerHTML = '';
 
-    // Persist selection
-    chrome.storage.sync.set({ selectedBoardId: boardId, selectedGroupId: groupId });
+    // Do NOT persist the selection here — the default configuration is managed
+    // from the Settings page (Bug Lists). Ad-hoc board/group changes on this
+    // page are one-off for the current lookup.
 
     chrome.runtime.sendMessage(
       { action: 'findItemByName', boardId, groupId, name },

--- a/settings.html
+++ b/settings.html
@@ -52,10 +52,22 @@
         </div>
       </section>
 
-      <!-- Board & Group Selection -->
+      <!-- Bug Lists (saved configurations) -->
       <section class="settings-section">
-        <h2>Board & Group Selection</h2>
-        
+        <h2>Bug Lists</h2>
+        <p class="help-text section-intro">
+          Save one or more Board + Group combinations. The popup will let you switch between them.
+          The <strong>Default</strong> configuration is used when creating or updating bugs.
+        </p>
+
+        <!-- Saved Configurations List -->
+        <div class="saved-configurations" id="savedConfigurations">
+          <div class="empty-state-inline">No configurations saved yet. Add your first one below.</div>
+        </div>
+
+        <!-- Add Configuration Form -->
+        <h3 class="subsection-title">Add a Configuration</h3>
+
         <div class="boards-search-container">
           <div class="form-group">
             <label for="boardSearch">Search Boards:</label>
@@ -93,7 +105,7 @@
           </select>
         </div>
 
-        <button type="button" class="primary-btn" id="saveSelectionBtn">Save Selection</button>
+        <button type="button" class="primary-btn" id="addConfigurationBtn">Add Configuration</button>
       </section>
       <!-- Privacy & Consent -->
       <section class="settings-section">

--- a/styles/popup.css
+++ b/styles/popup.css
@@ -117,6 +117,46 @@ body {
   }
 }
 
+/* Config Switcher */
+.config-switcher {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  background: white;
+  border-bottom: 1px solid #e1e4e8;
+}
+
+.config-switcher[hidden] {
+  display: none;
+}
+
+.config-switcher-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: #6a737d;
+  flex-shrink: 0;
+}
+
+.config-switcher-select {
+  flex: 1;
+  min-width: 0;
+  padding: 6px 10px;
+  border: 1px solid #d1d5da;
+  border-radius: 6px;
+  font-family: inherit;
+  font-size: 13px;
+  background: white;
+  cursor: pointer;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.config-switcher-select:focus {
+  outline: none;
+  border-color: #EB8634;
+  box-shadow: 0 0 0 3px rgba(235, 134, 52, 0.1);
+}
+
 /* Search Container */
 .search-container {
   position: relative;

--- a/styles/settings.css
+++ b/styles/settings.css
@@ -366,6 +366,124 @@ select optgroup {
   box-shadow: 0 4px 12px rgba(220, 53, 69, 0.4);
 }
 
+/* Saved Configurations (Bug Lists) */
+.section-intro {
+  margin-bottom: 16px;
+  line-height: 1.6;
+}
+
+.subsection-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: #24292e;
+  margin: 20px 0 12px;
+  padding-top: 16px;
+  border-top: 1px solid #e1e4e8;
+}
+
+.saved-configurations {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-bottom: 16px;
+}
+
+.empty-state-inline {
+  padding: 16px;
+  text-align: center;
+  background: #f6f8fa;
+  border: 1px dashed #d1d5da;
+  border-radius: 6px;
+  color: #6a737d;
+  font-size: 13px;
+}
+
+.config-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 14px;
+  background: #f6f8fa;
+  border: 1px solid #e1e4e8;
+  border-radius: 6px;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.config-row.is-default {
+  border-color: #0D6391;
+  background: #f0f7fb;
+}
+
+.config-row-main {
+  flex: 1;
+  min-width: 0;
+}
+
+.config-row-title {
+  font-weight: 500;
+  color: #24292e;
+  font-size: 14px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.config-row-meta {
+  font-size: 12px;
+  color: #6a737d;
+  margin-top: 2px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.config-row-actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.config-badge {
+  display: inline-block;
+  padding: 4px 10px;
+  background: #0D6391;
+  color: white;
+  border-radius: 12px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+}
+
+.config-action-btn {
+  padding: 6px 12px;
+  background: white;
+  border: 1px solid #d1d5da;
+  border-radius: 6px;
+  font-size: 12px;
+  font-weight: 500;
+  color: #24292e;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.config-action-btn:hover:not(:disabled) {
+  border-color: #EB8634;
+  background: #fff8f0;
+}
+
+.config-action-btn.remove-btn:hover:not(:disabled) {
+  border-color: #dc3545;
+  background: #fdf0f1;
+  color: #dc3545;
+}
+
+.config-action-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 /* Privacy Notice */
 .privacy-notice {
   background: #fff3cd;


### PR DESCRIPTION
Add multi-board/group support with a popup switcher. 
Users can save multiple Board + Group configurations in Settings (with Default / Set as default / Remove controls) and flip between them via a dropdown in the popup, which refetches the bug list on change.
<img width="397" height="482" alt="image" src="https://github.com/user-attachments/assets/0932bcdb-0310-421b-a7bc-d4c31dc561d0" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes persisted settings/storage semantics (migration + syncing legacy keys) and increases Monday API fetch volume via cursor pagination, which could impact performance or quota limits.
> 
> **Overview**
> Adds **multi-board/group “Bug Lists”**: users can save multiple Board+Group configurations in Settings (set default/remove), and the popup can switch between them via a dropdown that refetches the bug list.
> 
> Updates storage behavior to manage configurations (`savedConfigurations`/`defaultConfigurationId`) with a one-time migration from legacy `selectedBoardId`/`selectedGroupId`, keeps legacy keys synced to the default for compatibility, and stops `create-bug.js` from persisting ad-hoc board/group changes.
> 
> Extends Monday API bug fetching to follow `items_page.cursor`/`next_items_page` pagination (higher default limit) and updates `background.js` to accept optional `boardId`/`groupId` overrides when fetching recent bugs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6dde8da6f1c5e2936b78f16a5540badd7ec67b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->